### PR TITLE
Add autodiscovery link tag for Atom feed

### DIFF
--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -4,6 +4,7 @@
     %meta{ charset: "utf-8" }
     %meta{ content: "IE=edge,chrome=1", "http-equiv" => "X-UA-Compatible" }
     %meta{ name: "viewport", content: "width=device-width, initial-scale=1" }
+    %link{ rel: "alternate", type: "application/atom+xml", href: url_for("/feed.xml"), title: "Atom Feed" }
 
     %title
       = current_page.data.title || "Panter Blog"


### PR DESCRIPTION
Follow-up to #19, just remembered about the `<link>` tag for feeds :)